### PR TITLE
Fix Set for map[string]interface{} values

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -57,7 +57,10 @@ func (v View) Set(key string, value interface{}) {
 		name := subkeys[0]
 		view, ok := v[name].(View)
 		if !ok {
-			view = make(View)
+			view, ok = v[name].(map[string]interface{})
+			if !ok {
+				view = make(View)
+			}
 		}
 		view.Set(subkeys[1], value)
 		v[name] = view


### PR DESCRIPTION
When setting an inner value, if the outer value is a `map[string]interface{}` it is overwritten with a new `View` instead of being converted to a `View`.
Example: https://play.golang.org/p/lQ4bxf7OhSG

With this fix, the outer value will be referenced as a `View`, allowing the inner value to be set without overwriting the entire outer value (map).